### PR TITLE
Fix: Correct syntax for InsertUser type definition in schema.ts

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -65,7 +65,8 @@ export const users = pgTable("users", {
 });
 
 export type User = typeof users.$inferSelect;
-export type InsertUser = z.infer<typeof createInsertSchema(users)>;
+export const insertUserSchema = createInsertSchema(users);
+export type InsertUser = z.infer<typeof insertUserSchema>;
 
 export const appointments = pgTable("appointments", {
   id: serial("id").primaryKey(),


### PR DESCRIPTION
The previous syntax for defining the InsertUser type using z.infer resulted in a parsing error: "Expected ">" but found "("".

This commit fixes the error by introducing an intermediate constant `insertUserSchema` to hold the Zod schema generated by `createInsertSchema(users)`. The `InsertUser` type is then inferred from this constant using `z.infer<typeof insertUserSchema>`.

This approach aligns with the pattern used for other type definitions in the same file and resolves the `drizzle-kit push` error.