### PR TITLE
Fix(client): Correct import path for useToast in AddAppointmentModal

### DIFF
--- a/client/src/components/AddAppointmentModal.tsx
+++ b/client/src/components/AddAppointmentModal.tsx
@@ -10,7 +10,7 @@ import { Calendar } from "@/components/ui/calendar";
 import { format } from "date-fns";
 import { cn } from "@/lib/utils";
 import type { Appointment } from '@/pages/CalendarPage';
-import { useToast } from "@/components/ui/use-toast"; // Added useToast
+import { useToast } from "@/hooks/use-toast"; // Added useToast
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"; // Added Alert
 import { AlertTriangle } from 'lucide-react'; // Added AlertTriangle
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -65,7 +65,8 @@ export const users = pgTable("users", {
 });
 
 export type User = typeof users.$inferSelect;
-export type InsertUser = z.infer<typeof createInsertSchema(users)>;
+export const insertUserSchema = createInsertSchema(users);
+export type InsertUser = z.infer<typeof insertUserSchema>;
 
 export const appointments = pgTable("appointments", {
   id: serial("id").primaryKey(),


### PR DESCRIPTION
The AddAppointmentModal.tsx component was attempting to import the useToast hook from "@c/components/ui/use-toast", but the hook is located at "@c/hooks/use-toast.ts".

This commit updates the import path to the correct location, resolving the Vite module resolution error "Failed to resolve import".