### PR TITLE
Fix(client): Use useLocation for navigation in Sidebar

### DIFF
--- a/client/src/components/AddAppointmentModal.tsx
+++ b/client/src/components/AddAppointmentModal.tsx
@@ -10,7 +10,7 @@ import { Calendar } from "@/components/ui/calendar";
 import { format } from "date-fns";
 import { cn } from "@/lib/utils";
 import type { Appointment } from '@/pages/CalendarPage';
-import { useToast } from "@/components/ui/use-toast"; // Added useToast
+import { useToast } from "@/hooks/use-toast"; // Added useToast
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"; // Added Alert
 import { AlertTriangle } from 'lucide-react'; // Added AlertTriangle
 

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation, useNavigate } from "wouter";
+import { Link, useLocation } from "wouter";
 import { LayoutDashboard, Users, Building, Calendar, BarChart3, LogOut, CalendarDays } from "lucide-react"; // Added LogOut & CalendarDays
 import { jwtDecode } from 'jwt-decode'; // Added
 import { useEffect, useState } from 'react'; // Added
@@ -45,8 +45,7 @@ const navigationItems = [
 ];
 
 export default function Sidebar() {
-  const [location] = useLocation();
-  const navigate = useNavigate(); // Added
+  const [location, navigate] = useLocation(); // Corrected to use useLocation
   const [username, setUsername] = useState<string | null>(null); // Added
 
   useEffect(() => { // Added

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -3,13 +3,13 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Link, useNavigate } from 'wouter';
+import { Link, useLocation } from 'wouter';
 
 const LoginPage = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -3,14 +3,14 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Link, useNavigate } from 'wouter';
+import { Link, useLocation } from 'wouter';
 
 const RegisterPage = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -65,7 +65,8 @@ export const users = pgTable("users", {
 });
 
 export type User = typeof users.$inferSelect;
-export type InsertUser = z.infer<typeof createInsertSchema(users)>;
+export const insertUserSchema = createInsertSchema(users);
+export type InsertUser = z.infer<typeof insertUserSchema>;
 
 export const appointments = pgTable("appointments", {
   id: serial("id").primaryKey(),


### PR DESCRIPTION
Replaces the incorrect use of `useNavigate` with the correct `useLocation` hook for programmatic navigation in `client/src/components/Sidebar.tsx`.

This resolves a build error caused by `useNavigate` not being an export of `wouter@3.3.5`. The `useLocation` hook provides a setter function for navigation, which is now used. This change makes the Sidebar consistent with other components that use wouter for navigation.