### PR TITLE
fix: Improve client-side handling of 401 errors

### DIFF
--- a/client/src/components/AddEmployeeModal.tsx
+++ b/client/src/components/AddEmployeeModal.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
-import { queryClient, apiRequest } from "@/lib/queryClient";
+import { queryClient, apiRequest, ApiError } from "@/lib/queryClient"; // Imported ApiError
 import type { Department, Employee } from "@/lib/types"; // Added Employee type
 
 interface AddEmployeeModalProps {
@@ -90,12 +90,20 @@ export default function AddEmployeeModal({ isOpen, onClose, employeeToEdit }: Ad
       onClose();
       // resetForm(); // Removed, useEffect and onClose prop should handle this
     },
-    onError: () => {
-      toast({
-        title: "Error",
-        description: employeeToEdit ? "Failed to update employee" : "Failed to add employee",
-        variant: "destructive",
-      });
+    onError: (error) => { // Added error parameter
+      if (error instanceof ApiError && error.status === 401) {
+        toast({
+          title: "Authorization Error",
+          description: "Your session may have expired or your authorization is invalid. Please log out and log in again.",
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "Error",
+          description: employeeToEdit ? "Failed to update employee." : "Failed to add employee.",
+          variant: "destructive",
+        });
+      }
     },
   });
 


### PR DESCRIPTION
Introduced a custom `ApiError` class in `queryClient.ts` to ensure HTTP status codes and server messages are propagated from API requests.

Updated `AddEmployeeModal.tsx` to use this `ApiError`:
- The `onError` handler for the save employee mutation now checks for `ApiError` instances with a status of 401.
- If a 401 error occurs (e.g., due to an expired or invalid token), a specific toast notification is displayed to you, guiding you to log out and log in again.
- Generic error messages are retained for other types of errors.

This change provides more actionable feedback to you when encountering authorization issues, particularly when your session token expires.