### PR TITLE
feat: Implement sorting of employees by department name

### DIFF
--- a/client/src/pages/Employees.tsx
+++ b/client/src/pages/Employees.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
-import { Plus, Search, Eye, Edit, Trash2, Users } from "lucide-react";
+import { Plus, Search, Eye, Edit, Trash2, Users, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import AddEmployeeModal from "@/components/AddEmployeeModal";
@@ -22,10 +22,36 @@ export default function Employees() {
   const [selectedEmployeeForEdit, setSelectedEmployeeForEdit] = useState<Employee | null>(null); // Added for edit
   const [isViewModalOpen, setIsViewModalOpen] = useState(false); // Added
   const [selectedEmployeeForView, setSelectedEmployeeForView] = useState<Employee | null>(null); // Added
+  const [sortColumn, setSortColumn] = useState<string>("");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc" | "none">("none");
   const { toast } = useToast();
 
+  const handleSort = (columnId: string) => {
+    if (sortColumn === columnId) {
+      if (sortDirection === "asc") {
+        setSortDirection("desc");
+      } else if (sortDirection === "desc") {
+        setSortDirection("none");
+        setSortColumn("");
+      } else {
+        setSortDirection("asc");
+      }
+    } else {
+      setSortColumn(columnId);
+      setSortDirection("asc");
+    }
+  };
+
   const { data: employees = [], isLoading: loadingEmployees } = useQuery<Employee[]>({
-    queryKey: ["/api/employees", { search: searchQuery || undefined, department: selectedDepartment !== "all" ? selectedDepartment : undefined }],
+    queryKey: [
+      "/api/employees",
+      {
+        search: searchQuery || undefined,
+        department: selectedDepartment !== "all" ? selectedDepartment : undefined,
+        sortBy: sortColumn || undefined,
+        order: sortDirection !== "none" ? sortDirection : undefined,
+      },
+    ],
   });
 
   const { data: departments = [] } = useQuery<Department[]>({
@@ -163,7 +189,25 @@ export default function Employees() {
                   <TableRow>
                     <TableHead>Employee</TableHead>
                     <TableHead>Position</TableHead>
-                    <TableHead>Department</TableHead>
+                    <TableHead>
+                      <Button
+                        variant="ghost"
+                        onClick={() => handleSort("department")}
+                      >
+                        Department
+                        {sortColumn === "department" ? (
+                          sortDirection === "asc" ? (
+                            <ArrowUp className="ml-2 h-4 w-4" />
+                          ) : sortDirection === "desc" ? (
+                            <ArrowDown className="ml-2 h-4 w-4" />
+                          ) : (
+                            <ArrowUpDown className="ml-2 h-4 w-4" />
+                          )
+                        ) : (
+                          <ArrowUpDown className="ml-2 h-4 w-4" />
+                        )}
+                      </Button>
+                    </TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead>Start Date</TableHead>
                     <TableHead>Actions</TableHead>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -129,15 +129,19 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Employee routes
   app.get("/api/employees", authMiddleware, async (req, res) => {
     try {
-      const { search, department } = req.query;
+      const { search, department, sortBy, order } = req.query;
       let employees;
 
+      // Ensure sortBy and order are strings or undefined
+      const sortByString = sortBy as string | undefined;
+      const orderString = order as string | undefined;
+
       if (search) {
-        employees = await storage.searchEmployees(search as string);
+        employees = await storage.searchEmployees(search as string, sortByString, orderString);
       } else if (department) {
-        employees = await storage.getEmployeesByDepartment(parseInt(department as string));
+        employees = await storage.getEmployeesByDepartment(parseInt(department as string), sortByString, orderString);
       } else {
-        employees = await storage.getEmployees();
+        employees = await storage.getEmployees(sortByString, orderString);
       }
 
       res.json(employees);


### PR DESCRIPTION
This commit introduces functionality to sort the employee list by department name on the Employees page.

Key changes:

-   **Frontend (`client/src/pages/Employees.tsx`):**
    -   Added a clickable sort button to the 'Department' column header.
    -   The button cycles through ascending, descending, and no sort states.
    -   Sort state (column and direction) is managed in the component's state.
    -   The `useQuery` hook for fetching employees now sends `sortBy=department` and `order=[asc|desc]` parameters to the API when sorting is active.

-   **Backend API (`server/routes.ts`):**
    -   The `GET /api/employees` endpoint now accepts `sortBy` and `order` query parameters.
    -   These parameters are passed down to the storage layer functions.

-   **Storage Layer (`server/storage.ts`):**
    -   Modified `getEmployees`, `getEmployeesByDepartment`, and `searchEmployees` to accept `sortBy` and `order` parameters.
    -   When `sortBy` is 'department', the SQL queries now include an `ORDER BY departments.name [ASC|DESC] NULLS LAST` clause. This ensures correct alphabetical sorting by the actual department name and consistent handling of employees not assigned to a department.
    -   Improved data consistency by ensuring `departmentName` in employee results is sourced directly from the joined `departments` table.
    -   Updated employee search to query against `departments.name` for department-related terms.

Verification of the sort order via automated tests was inconclusive due to authentication issues in the test environment. Manual verification in a populated and authenticated environment is recommended to confirm end-to-end functionality.