### PR TITLE
fix: Ensure `leave_types` table exists and is seeded

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -8,7 +8,9 @@ import { drizzle as drizzleNodePostgres } from 'drizzle-orm/node-postgres';
 import { Pool as NeonPool, neonConfig } from '@neondatabase/serverless';
 import { drizzle as drizzleNeonServerless } from 'drizzle-orm/neon-serverless';
 import ws from "ws"; // Required for Neon serverless over WebSocket
+import { sql } from "drizzle-orm";
 import * as schema from "@shared/schema";
+import { leave_types, LeaveType } from "@shared/schema";
 
 if (!process.env.DATABASE_URL) {
   throw new Error(
@@ -31,8 +33,74 @@ if (process.env.NODE_ENV === 'production') {
   console.log("Initializing node-postgres (pg) driver for development environment.");
   const pgPoolInstance = new PgPool({ connectionString: process.env.DATABASE_URL });
   pool = pgPoolInstance;
-  db = drizzleNodePostgres(pgPoolInstance, { schema }); // Drizzle for node-postgres takes the pool directly
+  db = drizzleNodePostgres(pgPoolInstance, { schema });
   console.log("node-postgres (pg) driver initialized successfully.");
 }
 
-export { db, pool, schema };
+// Function to ensure leave_types table exists
+async function ensureLeaveTypesTableExists() {
+    console.log("Checking and ensuring 'leave_types' table exists...");
+    try {
+        await db.execute(sql`
+            CREATE TABLE IF NOT EXISTS leave_types (
+                id SERIAL PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT,
+                default_days INTEGER DEFAULT 0
+            );
+        `);
+        console.log("'leave_types' table check/creation successful.");
+    } catch (error) {
+        console.error("Error ensuring 'leave_types' table exists:", error);
+        // Rethrow the error to prevent seeding if table creation fails
+        throw error;
+    }
+}
+
+// Define default leave types
+const defaultLeaveTypes: Omit<LeaveType, 'id'>[] = [
+    { name: "Annual Leave", description: "Annual vacation leave", defaultDays: 20 },
+    { name: "Sick Leave", description: "Leave for personal illness", defaultDays: 10 },
+    { name: "Unpaid Leave", description: "Leave without pay", defaultDays: 0 },
+    { name: "Bereavement Leave", description: "Leave for mourning a close relative", defaultDays: 5 },
+    { name: "Maternity Leave", description: "Leave for new mothers", defaultDays: 90 },
+];
+
+// Seeding function for leave types
+async function seedLeaveTypes() {
+    console.log("Checking and seeding leave types if necessary...");
+    try {
+        const result = await db.select({ count: sql<number>`count(*)` }).from(leave_types);
+        const count = result[0]?.count ?? 0;
+
+        if (count === 0) {
+            console.log("Leave types table is empty. Seeding default leave types...");
+            // Note: Drizzle ORM expects camelCase keys that match the schema definition
+            // The actual SQL column names (snake_case) are handled by Drizzle during insertion.
+            for (const lt of defaultLeaveTypes) {
+                await db.insert(leave_types).values(lt);
+                console.log(`Inserted leave type: ${lt.name}`);
+            }
+            console.log("Leave types seeding completed successfully.");
+        } else {
+            console.log("Leave types table already has data. Seeding skipped.");
+        }
+    } catch (error) {
+        console.error("Error seeding leave types:", error);
+    }
+}
+
+// Initialize database (create table if not exists, then seed)
+console.log("Preparing to ensure table exists and seed data...");
+(async () => {
+  try {
+    await ensureLeaveTypesTableExists();
+    await seedLeaveTypes();
+  } catch (error) {
+    console.error("Error during database initialization:", error);
+    // Optionally, exit the process if initialization fails critically
+    // process.exit(1);
+  }
+})().catch(console.error); // Outer catch for the IIFE itself, though errors within should be handled.
+
+export { db, pool, schema, defaultLeaveTypes, seedLeaveTypes, ensureLeaveTypesTableExists };


### PR DESCRIPTION
Problem:
The 'My Leave' page did not display any leave types for your selection. This was due to the `leave_types` table potentially not existing or being empty in the database, and the initial seeding logic might not have been robust enough.

Solution:
This commit implements a more robust mechanism to ensure leave types are available:
1.  Automatic Table Creation:
    - I added a function `ensureLeaveTypesTableExists` in `server/db.ts` that executes a `CREATE TABLE IF NOT EXISTS leave_types ...` SQL command on application startup. This ensures the table structure is present.
2.  Refined Seeding Logic:
    - The `seedLeaveTypes` function in `server/db.ts` is called immediately after I ensure the table existence.
    - This function populates the `leave_types` table with a default set of common leave types (Annual, Sick, Unpaid, etc.) only if the table is currently empty.
3.  Enhanced Logging:
    - I added detailed console logging throughout the table creation and seeding process in `server/db.ts` to aid in monitoring and diagnosing any issues during startup.
    - I ensured `DATABASE_URL` presence is checked.

These changes ensure that the necessary database table and data are consistently available, resolving the issue where you could not select a leave type.