### PR TITLE
I've added a seeding mechanism for core leave types.

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ dotenv.config({ path: path.resolve(__dirname, '.env'), override: true });
 console.log('DATABASE_URL directly in index.ts:', process.env.DATABASE_URL);
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
+import { storage } from "./storage"; // Import storage
 import { setupVite, serveStatic, log } from "./vite"; // cache-busting comment
 
 
@@ -45,6 +46,15 @@ app.use((req, res, next) => {
 
 (async () => {
   const server = await registerRoutes(app);
+
+  // Seed initial data
+  try {
+    await storage.seedInitialLeaveTypes();
+  } catch (error) {
+    console.error("Failed to seed initial leave types:", error);
+    // Depending on the application's requirements, you might want to exit here
+    // process.exit(1);
+  }
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -683,6 +683,37 @@ export class DatabaseStorage implements IStorage {
       throw new Error("Could not adjust leave balance.");
     }
   }
+
+  async seedInitialLeaveTypes() {
+    const coreLeaveTypes = [
+      { name: "Sick Leave", description: "Leave taken due to illness.", defaultDays: 10 },
+      { name: "Personal Leave", description: "Leave taken for personal reasons.", defaultDays: 5 },
+      { name: "Business Leave", description: "Leave taken for business-related travel or activities.", defaultDays: 7 },
+      { name: "Annual Leave", description: "Standard annual vacation leave.", defaultDays: 15 }
+    ];
+
+    console.log("Attempting to seed initial leave types...");
+
+    for (const lt of coreLeaveTypes) {
+      try {
+        const existing = await this.db
+          .select()
+          .from(leave_types)
+          .where(eq(leave_types.name, lt.name))
+          .limit(1);
+
+        if (existing.length === 0) {
+          await this.db.insert(leave_types).values(lt);
+          console.log(`Seeded leave type: ${lt.name}`);
+        } else {
+          console.log(`Leave type already exists: ${lt.name}`);
+        }
+      } catch (error) {
+        console.error(`Error seeding leave type ${lt.name}:`, error);
+      }
+    }
+    console.log("Finished seeding initial leave types.");
+  }
 }
 
 export const storage = new DatabaseStorage();


### PR DESCRIPTION
This ensures that essential leave types (Sick Leave, Personal Leave, Business Leave, Annual Leave) are present in the database.

- I added a `seedInitialLeaveTypes` function to `server/storage.ts`. This function checks for the existence of these core leave types by name and inserts them if they are missing, along with a description and default number of days.
- I made sure the seeding function is called during server startup in `server/index.ts` to ensure the leave types are available when your application runs.

This change addresses your requirement to have these specific leave types available in the "Apply for Leave" section of the "My Leave" tab. The existing UI in `MyLeavePage.tsx` will now be populated with these types, and the leave balance and request submission features will function correctly with them, assuming corresponding leave balances are configured for employees by an administrator.