### PR TITLE
Fix: Resolve issues in My Leave page functionality

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -50,8 +50,9 @@ app.use((req, res, next) => {
   // Seed initial data
   try {
     await storage.seedInitialLeaveTypes();
+    await storage.seedInitialEmployeeAndBalances(); // Call the new seeding function
   } catch (error) {
-    console.error("Failed to seed initial leave types:", error);
+    console.error("Failed to seed initial data:", error); // Generalize error message
     // Depending on the application's requirements, you might want to exit here
     // Forcing exit if seeding fails:
     throw error; // Re-throw the error


### PR DESCRIPTION
- Implemented seeding for employees, leave types, and leave balances to ensure data is available for the 'My Leave' page. Employee with ID 1 ('John Doe') is seeded with balances for 'Annual Leave' and 'Sick Leave'.
- Verified that API endpoints (/api/leave-types, /api/employees/:employeeId/leave-balances) correctly serve the seeded data.
- Confirmed frontend logic in MyLeavePage.tsx correctly consumes API data for leave type selection, balance display, and form submission.

This resolves issues where leave types could not be selected, leave balances were not displayed, and the submit button was inactive due to missing backend data.