### PR TITLE
Fix: Improve robustness of employee seeding logic

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -50,8 +50,9 @@ app.use((req, res, next) => {
   // Seed initial data
   try {
     await storage.seedInitialLeaveTypes();
+    await storage.seedInitialEmployeeAndBalances(); // Call the new seeding function
   } catch (error) {
-    console.error("Failed to seed initial leave types:", error);
+    console.error("Failed to seed initial data:", error); // Generalize error message
     // Depending on the application's requirements, you might want to exit here
     // Forcing exit if seeding fails:
     throw error; // Re-throw the error


### PR DESCRIPTION
The `seedInitialEmployeeAndBalances` method in `server/storage.ts` was failing with a unique constraint violation if employee ID 1 did not exist but the email "john.doe@example.com" was already in use by another employee.

This commit refactors the seeding logic to:
- Check if Employee ID 1 exists. If so, use it for balance seeding.
- If Employee ID 1 does not exist, check if the email "john.doe@example.com" is already in use.
  - If the email is taken by a different employee ID, log a warning about the conflict and skip attempts to create "John Doe" or seed balances for ID 1.
  - If the email is available, create a new "John Doe" employee. Log the actual ID of this new employee. If it's not 1, warn about the potential mismatch with frontend expectations but seed balances for the new employee's ID.
- Ensure balance seeding only proceeds if a target employee ID has been successfully identified or created.

This prevents the duplicate key error and provides clearer feedback if the database state conflicts with seeding assumptions for tests.